### PR TITLE
Add -fno-use-linker-plugin to CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_CONFIG_HEADERS([src/config.h])
 
 AC_CANONICAL_HOST
 
-CFLAGS="${CFLAGS:+$CFLAGS }-mlongcalls"
+CFLAGS="${CFLAGS:+$CFLAGS }-mlongcalls -fno-use-linker-plugin"
 LDFLAGS="${LDFLAGS:+$LDFLAGS }-nostdlib"
 
 AM_PROG_AS


### PR DESCRIPTION
On cygwin I got following error:
```
xtensa-lx106-elf-gcc: fatal error: -fuse-linker-plugin, but liblto_plugin.so not found
```
I suspect in my Cygwin system the default value of the compiler is the option -fuse-linker-plugin.
If the option already defaults to -fno-use-linker-plugin there will be no problem.
I do not know if there is a better place than configure.ac