### PR TITLE
Allow compiling w/ autoconf 2.68

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 # See the LICENSE file.
 #
 
-AC_PREREQ([2.69])
+AC_PREREQ([2.68])
 AC_INIT([lx106-hal], [rc-2010.1])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])


### PR DESCRIPTION
This version is part of Ubuntu 12.04, so used by at least one major supported distribution at the moment.

This change should have no negative impact on systems with newer autoconf.