### PR TITLE
Cleanup git status & build, still recursive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,29 @@
-*.a
-*.o
-Makefile
-Makefile.in
-.deps/
-
+# autoreconf
 /aclocal.m4
 /autom4te.cache/
 /build-aux/
-/config.log
-/config.status
 /configure
-/src/config.h
+/include/Makefile.in
+/Makefile.in
 /src/config.h.in
-/src/stamp-h1
+/src/Makefile.in
+
+# configure
+.deps/
+config.h
+config.log
+config.status
+Makefile
+stamp-h1
+
+# make all
+*.o
+*.S
+*-split.mk
+*--*.c
+libhal.a
+
+# make dist*
+lx106-hal-*.shar.gz
+lx106-hal-*.tar.*
+lx106-hal-*.zip

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,8 +78,8 @@ endif
 			print "\techo \"#define " $$2 "\" >\"$$@.splittmp\""; \
 			print "\techo \"#include \\\"$<\\\"\" >>\"$$@.splittmp\""; \
 			print "\tmv \"$$@.splittmp\" \"$$@\""; \
-			print "libhal.a: " srcbase "--" tag ".o"; \
-			print "libhal_a_OBJECTS += " srcbase "--" tag ".o"; \
+			print "libhal.a: " srcbase "--" tag ".$$(OBJEXT)"; \
+			print "libhal_a_OBJECTS += " srcbase "--" tag ".$$(OBJEXT)"; \
 		}' >"$@.splittmp"
 	mv "$@.splittmp" "$@"
 


### PR DESCRIPTION
- Clean up .gitignore so status shows clean after build even for VPATH builds
- Use OBJEXT variable for split sources Makefiles

This replaces #10 
